### PR TITLE
[#1141] Exclude j1 and j2 grade employees.

### DIFF
--- a/internal/repository/postgresdb/user.go
+++ b/internal/repository/postgresdb/user.go
@@ -230,7 +230,7 @@ func (us *userStore) ListUsers(ctx context.Context, reqData dto.ListUsersReq) (r
 		return
 	}
 
-	queryBuilder := repository.Sq.Select(userColumns...).From(us.UsersTable).OrderBy("first_name")
+	queryBuilder := repository.Sq.Select(userColumns...).From(us.UsersTable).Where("grade_id NOT IN (?, ?)", 1, 2).OrderBy("first_name")
 	conditions := []squirrel.Sqlizer{}
 	for _, name := range reqData.Name {
 		conditions = append(conditions, squirrel.Like{"lower(first_name)": "%" + name + "%"})


### PR DESCRIPTION
On peerly in search co-worker dropdown from where we can search employee to give an appreciation
,hide employees name/mail having grades  J1 and J2.

